### PR TITLE
Relax version range for serverless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-seed",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.20",
-    "serverless": "2.15.0"
+    "serverless": "^2.15.0"
   },
   "devDependencies": {
     "eslint": "^7.14.0",


### PR DESCRIPTION
Currently serverless is pinned, which means that including this package in your package.json will install serverless 2.15.0, even if you already have a dependency on another version. Allowing a range allows for deduplication of packages, which can speedup installs.